### PR TITLE
Fix `yes` for bash 5.0+

### DIFF
--- a/bin/yes
+++ b/bin/yes
@@ -3,5 +3,5 @@
 # yes in pure bash.
 
 for ((;;)); {
-    printf '%s\n' "${1:=y}"
+    printf '%s\n' "${1:-y}"
 }


### PR DESCRIPTION
The original snippet works fine in bash 4.4.23, but as of 5.0, assignments to a positional parameter are invalid. so bash just throws the error "./yes: line 6: $1: cannot assign in this way".